### PR TITLE
fix: add min-w-80 to fields columns to improve layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+  ### Fixed
+  - Fixed issue with fields column layout on long field names
+
 ## [1.0.10] - 2024-12-08
 
   ### Features

--- a/lib/components/Schema/Field/Base.tsx
+++ b/lib/components/Schema/Field/Base.tsx
@@ -26,7 +26,7 @@ export function FieldBase({
   return (
     <>
       <tr onClick={() => setUnderlyingShowed(!underlyingShowed)} className={hasUnderlying ? "cursor-pointer " : ""}>
-        <td className={`flex items-center flex-wrap`} style={{
+        <td className={`flex items-center flex-wrap min-w-80`} style={{
           paddingLeft: `${depth}em`
         }} >
           <div className="flex items-start">


### PR DESCRIPTION
The layout doesn't handle nicely long field names
Before / After below

![image](https://github.com/user-attachments/assets/d7b848b1-9b3d-4204-b6da-59efb5a8a6ea)
![image](https://github.com/user-attachments/assets/0ff119f3-da07-4076-9d9e-8ee203225e8b)
